### PR TITLE
Added CLI arguments for block/row size and pad

### DIFF
--- a/ccpuzzler.py
+++ b/ccpuzzler.py
@@ -34,6 +34,12 @@ def buildparser():
                             help='Keyword or keyphrase for the cipher sequence')
     cli_parser.add_argument('-r',
                             help='Include if the cipher sequence should be reversed.')
+    cli_parser.add_argument('--blocksize', type=int, default=5,
+                            help='Size of ciphertext block')
+    cli_parser.add_argument('--rowsize', type=int, default=8,
+                            help='Blocks per row in the ciphertext')
+    cli_parser.add_argument('-p', type=str, default='Z',
+                            help='Character used to pad ciphertext')
     return cli_parser
 
 def logkeygen(log, cli_args):
@@ -78,7 +84,7 @@ def logpuzzle(cli_args, plain, cipher, key):
     timestamp = now.strftime("%Y%m%d")
     # open log file
     try:
-        srcpath , _ = os.path.split(os.path.abspath(cli_args['fname'][0]))
+        srcpath, _ = os.path.split(os.path.abspath(cli_args['fname'][0]))
         filename = 'cc-' + cli_args['vnum'][0] + '-' + timestamp + '.txt'
         log = open(srcpath+'/'+filename, 'w')
         # file for saving ciphertext only
@@ -133,7 +139,10 @@ def main():
     # and the encipher dictionary
     plaintext = plain_file.read()
     # let's do this
-    ciphertext = encipher(plaintext, abet)
+    bsize = args['blocksize']
+    rsize = args['rowsize']
+    pad = args['p']
+    ciphertext = encipher(plaintext, abet, pad, bsize, rsize)
     #log the puzzle
     logpuzzle(args, plaintext, ciphertext, str(abet))
 

--- a/cipher/encipher.py
+++ b/cipher/encipher.py
@@ -8,7 +8,7 @@ Created on Sun Mar 22 16:24:11 2020
 
 import string
 
-def encipher(plaintext, alphabet, pad='Z', l_group=5, r_group=10):
+def encipher(plaintext, alphabet, pad, l_group, r_group):
     """
     Encipher the given plaintext using the given alphabet. Pad characters
     and grouping values can also be provided.
@@ -19,11 +19,11 @@ def encipher(plaintext, alphabet, pad='Z', l_group=5, r_group=10):
     alphabet : MonoAlphabet
         key
     pad : str, optional
-        letter used for padding. The default is 'Z'.
-    l_group : int, optional
-        size of letter group. The default is 5.
-    r_group : int, optional
-        size of row groups. The default is 5.
+        letter used for padding.
+    l_group : int
+        size of letter group
+    r_group : int,
+        size of row groups
     Returns
     -------
     string


### PR DESCRIPTION
The CLI now accepts arguments for the size of letter blocks,
the number of blocks per row, and the letter to be used
as a pad in ciphertext. These parameters were previously
optional parameters in encipher and defaults were set there.
They are now required positional arguments and defaults are
drawn from the CLI argument parser.